### PR TITLE
Update link to Grunt-repo as the current one fails to load

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"url": "git://github.com/sindresorhus/grunt-sass.git"
 	},
 	"dependencies": {
-		"grunt": "git+https://github.com/cowboy/grunt.git#0ba6d4b529",
+		"grunt": "https://nodeload.github.com/cowboy/grunt/tarball/0ba6d4b529",
 		"node-sass": "~0.2.2"
 	},
 	"engines": {


### PR DESCRIPTION
The current link to Grunt in the package.json-file of grunt-sass 0.2.0 fails to load Grunt for me.
The error I get is:

```
Error: `git "checkout" "0ba6d4b529"` failed with 1
    at ChildProcess.<anonymous> (/usr/local/Cellar/node/0.8.8/lib/node_modules/npm/lib/utils/exec.js:56:20)
    at ChildProcess.EventEmitter.emit (events.js:91:17)
    at Process._handle.onexit (child_process.js:674:10)
```

After changing the nodeload-url to the "normal" url instead of using git, it works for me.

Can you reproduce this? If so, here is a possible fix.
