### PR TITLE
Allow node-sass options to be passed.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -120,6 +120,24 @@ grunt.initConfig({
 });
 ```
 
+#### Compile files in a separate directory
+
+If you store your sass files in a directory other than root, you will need to
+add the path to the `include_paths` for `@import` to work as expected.
+
+```javascript
+grunt.initConfig({
+	sass: {
+		options: {
+			include_paths: ['path/to/sass']
+		},
+		files: {
+			'main.css': 'path/to/sass/main.scss',
+		}
+	}
+});
+```
+
 
 ## Contribute
 

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -8,6 +8,7 @@ module.exports = function(grunt) {
 		var helpers = require('grunt-lib-contrib').init(grunt);
 		var cb = this.async();
 		var sass = require('node-sass');
+		var options = this.data.options || {}
 		var async = grunt.util.async;
 
 		// TODO: ditch this when grunt v0.4 is released
@@ -27,7 +28,7 @@ module.exports = function(grunt) {
 				grunt.helper('min_max_info', css, max);
 
 				cb2();
-			});
+			}, options);
 		}, function(err) {
 			cb(!err);
 		});


### PR DESCRIPTION
Needed to be able to pass `include_paths` to node-sass.
