### PR TITLE
Add success logging

### DIFF
--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -13,6 +13,7 @@ module.exports = function (grunt) {
 				file: el.src[0],
 				success: function (css) {
 					grunt.file.write(el.dest, css);
+					grunt.log.writeln('File "' + el.dest + '" created.');
 					next();
 				},
 				error: function (err) {


### PR DESCRIPTION
Most Grunt plugins seem to do this:

https://github.com/gruntjs/grunt-contrib-concat/blob/master/tasks/concat.js#L65
https://github.com/gruntjs/grunt-contrib-coffee/blob/master/tasks/coffee.js#L225
