### PR TITLE
Update node-sass version to 0.7.0-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "grunt"
   },
   "dependencies": {
-    "node-sass": "~0.6.2",
+    "node-sass": "~0.7.0-alpha",
     "grunt-lib-contrib": "~0.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
- Update node-sass from 0.6.2 to 0.7.0-alpha
- Merged with https://github.com/andrew/node-sass/pull/148
- Allows `npm install` without re-compiling every time
