### PR TITLE
Ignore "_" partial files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,6 +23,13 @@ module.exports = function (grunt) {
 					'test/tmp/source-comments.css': 'test/fixtures/test.scss'
 				}
 			},
+			ignorePartials: {
+				cwd: 'test/fixtures/partials',
+				src: '*.scss',
+				dest: 'test/tmp',
+				expand: true,
+				ext: '.css'
+			}
 		},
 		nodeunit: {
 			tasks: ['test/test.js']

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,7 @@ grunt.loadNpmTasks('grunt-sass');
 
 See the [Gruntfile](https://github.com/sindresorhus/grunt-sass/blob/master/Gruntfile.js) in this repo for a full example.
 
+Note: Files that begin with "_" are ignored even if they match the globbing pattern. This is done to match the expected [Sass partial behaviour](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#partials).
 
 ### Options
 

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -1,6 +1,7 @@
 'use strict';
 var sass = require('node-sass');
 var async = require('async');
+var path = require('path');
 
 module.exports = function (grunt) {
 	grunt.registerMultiTask('sass', 'Compile SCSS to CSS', function () {
@@ -11,8 +12,13 @@ module.exports = function (grunt) {
 		});
 
 		async.eachSeries(this.files, function (el, next) {
+			var src = el.src[0];
+			if (path.basename(src)[0] === '_') {
+				return next();
+			}
+
 			sass.render({
-				file: el.src[0],
+				file: src,
 				success: function (css) {
 					grunt.file.write(el.dest, css);
 					grunt.log.writeln('File "' + el.dest + '" created.');

--- a/test/fixtures/partials/_partial.scss
+++ b/test/fixtures/partials/_partial.scss
@@ -1,0 +1,3 @@
+.foo {
+	color: red;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -27,5 +27,12 @@ exports.sass = {
 		test.ok(/^\/\* line 1/.test(actual), 'should include sourceComments');
 
 		test.done();
+	},
+	ignorePartials: function (test) {
+		test.expect(1);
+
+		test.ok(!grunt.file.exists('test/tmp/_partial.css'), 'underscore partial files should be ignored');
+
+		test.done();
 	}
 };


### PR DESCRIPTION
This matches the expected behaviour in Ruby globbing.

A better issue description can be found in https://github.com/gruntjs/grunt-contrib-sass/issues/72, but I don't use the Ruby version anymore.

I didn't put this behind an option flag, but it might make sense.
