### PR TITLE
Basic support for sourcemaps

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,7 +33,7 @@ module.exports = function (grunt) {
 			sourceMap: {
 				options: {
 					sourceComments: 'map',
-					sourceMap: '.lib/stuff/source-map.css.map'
+					sourceMap: 'source-map.css.map'
 				},
 				files: {
 					'test/tmp/source-map.css': 'test/fixtures/test.scss'

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "grunt"
   },
   "dependencies": {
-    "node-sass-swist": "~0.7.0",
+    "node-sass": "~0.7.0",
     "async": "~0.2.9"
   },
   "devDependencies": {

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -22,7 +22,6 @@ module.exports = function (grunt) {
 				success: function (css, map) {
 					grunt.file.write(el.dest, css);
 					grunt.log.writeln('File "' + el.dest + '" created.');
-					grunt.log.writeln(options.sourceMap);
 					grunt.file.write(el.dest + '.map', map)
 					grunt.log.writeln('File "' + el.dest + '.map " created.');
 					next();


### PR DESCRIPTION
Salient points:
- sourcemaps currently can only live as a sibling of the .css
- Haven't tested if specifying the url for the sourcemap works, just had to pass something to node-sass for it to compile it. 
- Requires you to build node-sass from source

Perhaps merge once node-sass with sourcemap support shows up on npm?
