### PR TITLE
add sourcemap option set up logic

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,6 +39,22 @@ module.exports = function (grunt) {
 					'test/tmp/source-map.css': 'test/fixtures/test.scss'
 				}
 			},
+			sourceMapBySourceComment: {
+				options: {
+					sourceComments: 'map'
+				},
+				files: {
+					'test/tmp/source-map-sc.css': 'test/fixtures/test.scss'
+				}
+			},
+			sourceMapSimple: {
+				options: {
+					sourceMap: true
+				},
+				files: {
+					'test/tmp/source-map-simple.css': 'test/fixtures/test.scss'
+				}
+			},
 		},
 		nodeunit: {
 			tasks: ['test/test.js']

--- a/test/test.js
+++ b/test/test.js
@@ -44,5 +44,27 @@ exports.sass = {
 		var map = grunt.file.read('test/tmp/source-map.css.map');
 		test.ok(/\"file\"\: \"test\.scss\"/.test(map), 'should include the main file in sourceMap at least');
 		test.done();
+	},
+	sourceMapBySourceComment: function (test) {
+		test.expect(3);
+
+		var css = grunt.file.read('test/tmp/source-map-sc.css');
+		test.ok(/\/\*\# sourceMappingURL\=source\-map-sc\.css\.map/.test(css), 'should include sourceMapppingUrl');
+
+		var map = grunt.file.read('test/tmp/source-map-sc.css.map');
+		test.ok(/\"file\"\: \"test\.scss\"/.test(map), 'should include the main file in sourceMap at least');
+		test.ok(/\"sources\"\: \[\"\.\.\/fixtures\/test\.scss\"/.test(map), 'should resolve full path to test.scss');
+		test.done();
+	},
+	sourceMapSimple: function (test) {
+		test.expect(3);
+
+		var css = grunt.file.read('test/tmp/source-map-simple.css');
+		test.ok(/\/\*\# sourceMappingURL\=source\-map-simple\.css\.map/.test(css), 'should include sourceMappingUrl');
+
+		var map = grunt.file.read('test/tmp/source-map-simple.css.map');
+		test.ok(/\"file\"\: \"test\.scss\"/.test(map), 'should include the main file in sourceMap at least');
+		test.ok(/\"sources\"\: \[\"\.\.\/fixtures\/test\.scss\"/.test(map), 'should resolve path to test.scss');
+		test.done();
 	}
 };


### PR DESCRIPTION
Handles setting up smarter defaults for the sourcemap property.

Most of this logic is from:
https://github.com/andrew/node-sass/blob/9b752b2729f039590f15ffe239a61e60d0984c77/lib/cli.js#L119-L132

Resolves #57 and #58

Note: I didn't add tests for this change. Also, I added a FIXME note because it's getting late and I haven't thought about how whether to use the cwd.
