### PR TITLE
Add cache option to sass.js

### DIFF
--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -9,7 +9,8 @@ module.exports = function (grunt) {
 		var options = this.options({
 			includePaths: [],
 			outputStyle: 'nested',
-			sourceComments: 'none'
+			sourceComments: 'none',
+			cache: false
 		});
 
 		async.eachSeries(this.files, function (el, next) {
@@ -22,11 +23,23 @@ module.exports = function (grunt) {
 			sass.render({
 				file: src,
 				success: function (css, map) {
-					grunt.file.write(el.dest, css);
-					grunt.log.writeln('File ' + chalk.cyan(el.dest) + ' created.');
-
-					if (map) {
-						grunt.file.write(el.dest + '.map', map)
+					var performWrite = true,
+						targetContents;
+					
+					if(options.cache && grunt.file.exists(el.dest)) {
+						targetContents = grunt.file.read(el.dest);
+						performWrite = targetContents !== css;
+					}
+					
+					if(performWrite) {
+						grunt.file.write(el.dest, css);
+						grunt.log.writeln('File ' + chalk.cyan(el.dest) + ' created.');
+					} else {
+						grunt.log.writeln('Skipping ' + el.dest + '... identical');
+					}
+					
+					if(map) {
+						grunt.file.write(el.dest + '.map', map);
 						grunt.log.writeln('File ' + chalk.cyan(el.dest + '.map') + ' created.');
 					}
 


### PR DESCRIPTION
If cache is set to true, grunt-sass will only overwrite the file if the content has actually changed. This is helpful when using LiveReload, for example.
