### PR TITLE
Combine multiple source files

### DIFF
--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -25,14 +25,11 @@ module.exports = function (grunt) {
 		}
 
 		eachAsync(this.files, function (el, i, next) {
-			var src = el.src[0];
-
-			if (path.basename(src)[0] === '_') {
+			if (path.basename(el.dest)[0] === '_') {
 				return next();
 			}
 
 			var renderOpts = {
-				file: src,
 				success: function (css, map) {
 					grunt.file.write(el.dest, css);
 					grunt.log.writeln('File ' + chalk.cyan(el.dest) + ' created.');
@@ -49,6 +46,12 @@ module.exports = function (grunt) {
 				outputStyle: options.outputStyle,
 				sourceComments: options.sourceComments
 			};
+
+			if (el.src.length > 1) {
+				renderOpts.data = '@import "' + el.src.join('";\n@import "') + '";\n';
+			} else {
+				renderOpts.file = el.src[0];
+			}
 
 			if (options.sourceMap) {
 				if (options.sourceMap === true) {


### PR DESCRIPTION
This allows the task to be configured with files objects specifying multiple sources per destination file, like with grunt-contrib-concat. These are handled by passing an inline scss string in renderOpts.data which contains a top-level import directive for each of the source files to be merged into the same destination file. The usual "file" property is used, not "data", when only one source file is specified for any particular destination file.
