### PR TITLE
Add support for node-sass' imagePath option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,6 +15,14 @@ module.exports = function (grunt) {
 					'test/tmp/include-paths.css': 'test/fixtures/include-paths.scss'
 				}
 			},
+			imagePath: {
+				options: {
+					imagePath: '//cdn.test.com'
+				},
+				files: {
+					'test/tmp/image-path.css': 'test/fixtures/image-path.scss'
+				}
+			},
 			sourceComments: {
 				options: {
 					sourceComments: 'normal'

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,12 @@ Specify the CSS output style.
 
 *According to the [node-sass](https://github.com/andrew/node-sass) documentation, there is currently a problem with lib-sass so this option is best avoided for the time being.*
 
+#### imagePath
+
+Type: `String`
+Default: `""`
+
+Base path for `images-url`. See [node-sass documentation](https://github.com/andrew/node-sass#imagepath) for more info.
 
 #### sourceComments
 

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -46,6 +46,7 @@ module.exports = function (grunt) {
 				},
 				error: grunt.warn,
 				includePaths: options.includePaths,
+				imagePath: options.imagePath,
 				outputStyle: options.outputStyle,
 				sourceComments: options.sourceComments
 			};

--- a/test/fixtures/image-path.scss
+++ b/test/fixtures/image-path.scss
@@ -1,0 +1,3 @@
+.background-image {
+  background-image: image-url('image.png');
+}

--- a/test/test.js
+++ b/test/test.js
@@ -20,6 +20,14 @@ exports.sass = {
 
 		test.done();
 	},
+	imagePath: function (test) {
+		test.expect(1);
+
+		var actual = grunt.file.read('test/tmp/image-path.css');
+		test.ok(/\/\/cdn\.test\.com\/image.png/.test(actual), 'should process image-url according to imagePath');
+
+		test.done();
+	},
 	sourceComments: function (test) {
 		test.expect(1);
 


### PR DESCRIPTION
I added support for node-sass' imagePath option to grunt-sass. Simple enough.

The tests were failing on OSX and Ubuntu with latest node and npm when I started working on the PR, but not on Travis. I'm not sure what's going on there, but I'm pretty sure it's irrelevant to the changes I made.

Cheers,
## 

Fixes #64
