### PR TITLE
call this.async() on error

### DIFF
--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -44,7 +44,10 @@ module.exports = function (grunt) {
 
 					next();
 				},
-				error: grunt.warn,
+				error: function (error) {
+					grunt.warn(error);
+					next(error);
+				},
 				includePaths: options.includePaths,
 				imagePath: options.imagePath,
 				outputStyle: options.outputStyle,


### PR DESCRIPTION
If we use the --force option in grunt, we want the tasks to continue. So we need to call this.async() on error.
