### PR TITLE
Allow sourceMap as a function to compute map path

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,10 +65,10 @@ Represents the public image path. When using the `image-url()` function in a sty
 
 ### sourceMap
 
-Type: `boolean`, `string`  
+Type: `boolean`, `string`, `function`
 Default: `false`
 
-Set it to `true` to output a Source Map to the same location as the CSS *(output.css.map)*, or specify a path relative to the CSS file to where you want the Source Map.
+Set it to `true` to output a Source Map to the same location as the CSS *(output.css.map)*, or specify a path relative to the CSS file to where you want the Source Map. If the value is a function, it will be passed the destination path and should return a Source Map path relative to the destination.
 
 
 ### precision

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -22,6 +22,10 @@ module.exports = function (grunt) {
 				grunt.file.write(el.dest, '');
 			}
 
+			if (typeof options.sourceMap === 'function') {
+				options.sourceMap = options.sourceMap(el.dest);
+			}
+
 			sass.renderFile(assign({}, options, {
 				// temp workaround for sass/node-sass#425
 				file: path.resolve(src),


### PR DESCRIPTION
Given a function for sourceMap, pass it the destination file path so
that a source map path can be computed and returned.
