### PR TITLE
Ignore missing files

### DIFF
--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -14,7 +14,7 @@ module.exports = function (grunt) {
 
 			var src = el.src[0];
 
-			if (path.basename(src)[0] === '_') {
+			if (!src || path.basename(src)[0] === '_') {
 				return next();
 			}
 


### PR DESCRIPTION
If a file is missing the array in el.src is empty. This will skip this file to prevent errors on
resolving a path which isn't a string in line 28.
