### PR TITLE
Allow compiling partials via compilePartials: true

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+test/tmp

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,6 +31,15 @@ module.exports = function (grunt) {
 				expand: true,
 				ext: '.css'
 			},
+			compilePartials: {
+				options: {
+					sourceMap: false,
+					compilePartials: true
+				},
+				files: {
+					'test/tmp/compiled-partial.css': 'test/fixtures/partials/_partial.scss'
+				}
+			},
 			sourceMap: {
 				options: {
 					sourceMap: 'source-map.css.map'

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ grunt.registerTask('default', ['sass']);
 ```
 
 Files starting with `_` are ignored to match the expected [Sass partial behaviour](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#partials).
-
+Set the `compilePartials` option to `true` to override this.
 
 ## Options
 
@@ -78,6 +78,12 @@ Default: `10`
 
 Number of digits to preserve after the dot. With the number 1.23456789 and a precision of 3, the result will be 1.234 in the final CSS.
 
+### compilePartials
+
+Type: `boolean`
+Default: false
+
+Set it to `true` to compile the partials.
 
 ## License
 

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -9,12 +9,13 @@ module.exports = function (grunt) {
 	grunt.registerMultiTask('sass', 'Compile Sass to CSS', function () {
 		eachAsync(this.files, function (el, i, next) {
 			var options = this.options({
-				precision: 10
+				precision: 10,
+				compilePartials: false
 			});
 
 			var src = el.src[0];
 
-			if (!src || path.basename(src)[0] === '_') {
+			if (!src || !options.compilePartials && '_' === path.basename(src)[0]) {
 				return next();
 			}
 

--- a/test/test.js
+++ b/test/test.js
@@ -37,6 +37,14 @@ exports.sass = {
 
 		test.done();
 	},
+	compilePartials: function (test) {
+		test.expect(1);
+
+		test.ok(grunt.file.exists('test/tmp/compiled-partial.css'),
+				'underscore partial files should not be ignored with {compilePartials: true}');
+
+		test.done();
+	},
 	/*
 	sourceMap: function (test) {
 		test.expect(2);


### PR DESCRIPTION
This matches node-sass command line behaviour.