### PR TITLE
Update the sass task for node-sass 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "chalk": "^0.5.1",
     "each-async": "^1.0.0",
-    "node-sass": "1.2.3",
+    "node-sass": "2.0.0-beta",
     "object-assign": "^2.0.0"
   },
   "devDependencies": {

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -18,15 +18,11 @@ module.exports = function (grunt) {
 				return next();
 			}
 
-			if (!grunt.file.exists(el.dest)) {
-				grunt.file.write(el.dest, '');
-			}
-
-			sass.renderFile(assign({}, options, {
-				// temp workaround for sass/node-sass#425
+			sass.render(assign({}, options, {
 				file: path.resolve(src),
 				outFile: path.resolve(el.dest),
-				success: function (css, map) {
+				success: function(results) {
+					grunt.file.write(el.dest, results.css);
 					grunt.verbose.writeln('File ' + chalk.cyan(el.dest) + ' created.');
 
 					if (options.sourceMap) {
@@ -37,8 +33,8 @@ module.exports = function (grunt) {
 					next();
 				},
 				error: function (error) {
-					grunt.warn(error);
-					next(error);
+					grunt.warn(error.message);
+					next(error.message);
 				}
 			}));
 		}.bind(this), this.async());


### PR DESCRIPTION
This PR is just to leave open in case anyone wants to try out grunt-sass with node-sass 2.0.0 before the stable release