### PR TITLE
Don't write sourcemap file out when sourceMapEmbed

### DIFF
--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -26,7 +26,7 @@ module.exports = function (grunt) {
 				success: function (res) {
 					grunt.file.write(el.dest, res.css);
 
-					if (opts.sourceMap) {
+					if (opts.sourceMap && !opts.sourceMapEmbed) {
 						grunt.file.write(opts.sourceMap === true ? (el.dest + '.map') : path.relative(process.cwd(), opts.sourceMap), res.map);
 					}
 


### PR DESCRIPTION
Source maps can also be embedded directly in the CSS as a data URI. In this case we shouldn't write out an extra file.
https://github.com/sass/node-sass/blob/65619ba4e9e1e87465fc9576377733a6eef1e250/README.md#sourcemapembed