### PR TITLE
Allow specifying a directory for sourcemaps

### DIFF
--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -19,6 +19,10 @@ module.exports = function (grunt) {
 				next();
 				return;
 			}
+			
+			if (grunt.util.kindOf(opts.sourceMap) === 'string' && opts.sourceMap.match(/[\/\\]$/)) {
+				opts.sourceMap = opts.sourceMap + path.basename(el.dest) + '.map';
+			}
 
 			sass.render(assign({}, opts, {
 				file: src,

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -21,7 +21,7 @@ module.exports = function (grunt) {
 			}
 			
 			if (grunt.util.kindOf(opts.sourceMap) === 'string' && opts.sourceMap.match(/[\/\\]$/)) {
-				opts.sourceMap = opts.sourceMap + path.basename(el.dest) + '.map';
+				opts.sourceMap = path.normalize(opts.sourceMap + path.basename(el.dest) + '.map');
 			}
 
 			sass.render(assign({}, opts, {


### PR DESCRIPTION
At the moment there doesn't seem to be a way to get the sourcemaps generated in another directory than the source directory when you process multiple files in one target like:
```javascript
        files: [
            {
                src:  'app.scss',
                dest: 'app.css'
            }, {
                src:  'lib.scss',
                dest: 'lib.css'
            }
        ]
```
With this patch if the ``sourceMap`` option ends with ``/`` (or ``\``) …
```javascript
        options: {
            sourceMap: 'path/to/maps/'
        },
```
…  it is treated as directory and the sourcemap is named after the destination file with ``.map`` added.

With the example above you would get the following files generated in the end:
```
app.css
lib.css
path/to/maps/app.css.map
path/to/maps/lib.css.map
```

Another way to achieve this would have been to add a option like ``sourceMapDir``, but I thought this way it won't clash with existing behavior or possible extension of node-sass with  ``sourceMapDir``.