### PR TITLE
Added grunt.log.writeln('Processing ' + src) as process indicator.

### DIFF
--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -20,6 +20,8 @@ module.exports = function (grunt) {
 				return;
 			}
 
+			grunt.log.writeln('Processing ' + src);
+
 			sass.render(assign({}, opts, {
 				file: src,
 				outFile: el.dest


### PR DESCRIPTION
Added grunt.log.writeln('Processing ' + src) as a process indicator.

It might also be nice to display a total number of files processed (using a counter), but I confess I wasn't sure how to modify the 'completed' callback from `this.async()` to `eachAsync`.