### PR TITLE
Use node-sass@3.4.0-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "each-async": "^1.0.0",
-    "node-sass": "^3.0.0",
+    "node-sass": "^3.4.0-beta1",
     "object-assign": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
We've started releasing the [LibSass 3.3.0 betas](https://github.com/sass/libsass/releases/tag/3.3.0-beta1). In order to truly beta test LibSass 3.3.0 we real users to have the option to use it. Unfortunately due to the nature of LibSass being a library, the majority of our users come from node-sass via Grunt/Gulp Sass.

Node sass has start releasing their [v3.4.0 betas](https://github.com/sass/node-sass/releases/tag/v3.4.0-beta1) which enables the new LibSass betas.

We'd like for grunt-sass to release a 1.1.0 beta with an updated `node-sass@^v3.4.0-beta1` dependency so grunt-sass users can opt into beta testing LibSass 3.3.0. Using this version string means users _should_ be opted into all Node Sass 3.4.0 betas. 

Once Node Sass 3.4.0 is stable, Grunt Sass 1.1.0 stable can be released with `node-sass@v3.4.0`.

```
LibSass 3.3.0-betaX --> Node Sass 3.4.0-betaX --> Grunt Sass 1.1.0-beta
```