### PR TITLE
Show in the console the files successfully created

### DIFF
--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -32,7 +32,7 @@ module.exports = function (grunt) {
 				}
 
 				grunt.file.write(el.dest, res.css);
-				console.log("Writting " + el.dest);
+				grunt.log.writeln("Writting " + el.dest);
 
 				if (opts.sourceMap) {
 					grunt.file.write(this.options.sourceMap, res.map);

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -32,6 +32,7 @@ module.exports = function (grunt) {
 				}
 
 				grunt.file.write(el.dest, res.css);
+				console.log("Writting " + el.dest);
 
 				if (opts.sourceMap) {
 					grunt.file.write(this.options.sourceMap, res.map);


### PR DESCRIPTION
Currently there is no output to indicate which files were written.
In environments where is not possible to add `--verbose` to the execution, I think is useful to have this information.