### PR TITLE
Use LibSass' pre-formatted error messages. Fixes #201.

### DIFF
--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -25,7 +25,7 @@ module.exports = function (grunt) {
 				outFile: el.dest
 			}), function (err, res) {
 				if (err) {
-					grunt.log.error(err.message + '\n  ' + 'Line ' + err.line + '  Column ' + err.column + '  ' + path.relative(process.cwd(), err.file) + '\n');
+					grunt.log.error(err.formatted + '\n');
 					grunt.warn('');
 					next(err);
 					return;


### PR DESCRIPTION
Use LibSass' pre-formatted error messages. Fixes #201.

I couldn't figure how to capture the error message with the test suite. Feel free to add a test for this.

```
Running "sass:error" (sass) task
>> Error: error reading values after
>>         on line 1 of test/fixtures/error.scss
>> >> $foo:
>>    -----^
```