### PR TITLE
Fix running tests on Windows

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1,13 +1,21 @@
 'use strict';
 var grunt = require('grunt');
 
+/*
+ * Read files and normalize line endings.
+ * Makes tests work on Windows.
+ */
+function read(filename) {
+	return grunt.file.read(filename).replace(/\r/g, '');
+}
+
 exports.sass = {
 	compile: function (test) {
 		test.expect(2);
 
-		var actual = grunt.file.read('test/tmp/compile.css');
-		var actual2 = grunt.file.read('test/tmp/compile2.css');
-		var expected = grunt.file.read('test/expected/compile.css');
+		var actual = read('test/tmp/compile.css');
+		var actual2 = read('test/tmp/compile2.css');
+		var expected = read('test/expected/compile.css');
 		test.equal(actual, expected, 'should compile SCSS to CSS');
 		test.equal(actual2, expected, 'should compile SCSS to CSS');
 
@@ -16,8 +24,8 @@ exports.sass = {
 	includePaths: function (test) {
 		test.expect(1);
 
-		var actual = grunt.file.read('test/tmp/include-paths.css');
-		var expected = grunt.file.read('test/expected/include-paths.css');
+		var actual = read('test/tmp/include-paths.css');
+		var expected = read('test/expected/include-paths.css');
 		test.equal(actual, expected, 'should compile SCSS to CSS with options');
 
 		test.done();
@@ -32,27 +40,27 @@ exports.sass = {
 	sourceMap: function (test) {
 		test.expect(2);
 
-		var css = grunt.file.read('test/tmp/source-map.css');
+		var css = read('test/tmp/source-map.css');
 		test.ok(/\/\*\# sourceMappingURL\=source\-map\.css\.map/.test(css), 'should include sourceMapppingUrl');
 
-		var map = grunt.file.read('test/tmp/source-map.css.map');
+		var map = read('test/tmp/source-map.css.map');
 		test.ok(/test\.scss/.test(map), 'should include the main file in sourceMap at least');
 		test.done();
 	},
 	sourceMapSimple: function (test) {
 		test.expect(2);
 
-		var css = grunt.file.read('test/tmp/source-map-simple.css');
+		var css = read('test/tmp/source-map-simple.css');
 		test.ok(/\/\*\# sourceMappingURL\=source\-map-simple\.css\.map/.test(css), 'should include sourceMappingUrl');
 
-		var map = grunt.file.read('test/tmp/source-map-simple.css.map');
+		var map = read('test/tmp/source-map-simple.css.map');
 		test.ok(/test\.scss\"/.test(map), 'should include the main file in sourceMap at least');
 		test.done();
 	},
 	precision: function (test) {
 		test.expect(1);
 
-		var actual = grunt.file.read('test/tmp/precision.css');
+		var actual = read('test/tmp/precision.css');
 		test.ok(/1\.343/.test(actual), 'should support precision option');
 
 		test.done();


### PR DESCRIPTION
This is a simple change that removes carriage returns so the expected and actual files are not different because of difference in line ending style.