### PR TITLE
user-emitted errors do not have the formatted property. 

### DIFF
--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -25,7 +25,7 @@ module.exports = function (grunt) {
 				outFile: el.dest
 			}), function (err, res) {
 				if (err) {
-					grunt.log.error(err.formatted + '\n');
+					grunt.log.error((err.formatted ? err.formatted : err.message) + '\n');
 					grunt.warn('');
 					next(err);
 					return;


### PR DESCRIPTION
user-emitted errors (e.g. from importer functions) do not have the `formatted` property.

With the previous implementation (custom formatter) this even resulted in a fatal error due to the `file` property being non-existent

```
Fatal error: Arguments to path.resolve must be strings
```