### PR TITLE
Prepare 1.2.0-beta with node-sass@3.5.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-sass",
-  "version": "1.1.0",
+  "version": "1.2.0-beta",
   "description": "Compile Sass to CSS using node-sass",
   "license": "MIT",
   "repository": "sindresorhus/grunt-sass",
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "each-async": "^1.0.0",
-    "node-sass": "^3.4.0",
+    "node-sass": "beta",
     "object-assign": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Making sure tests pass. This will be released as a beta dist-tag.