### PR TITLE
Allow any version of node-sass to be used with this plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   ],
   "dependencies": {
     "each-async": "^1.0.0",
-    "node-sass": "beta",
     "object-assign": "^4.0.1"
   },
   "devDependencies": {
@@ -39,9 +38,11 @@
     "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-nodeunit": "^1.0.0",
+    "node-sass": "^3.5.3",
     "xo": "*"
   },
   "peerDependencies": {
-    "grunt": ">=0.4.0"
+    "grunt": ">=0.4.0",
+    "node-sass": "*"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -33,7 +33,7 @@ exports.sass = {
 		test.expect(2);
 
 		var css = grunt.file.read('test/tmp/source-map.css');
-		test.ok(/\/\*\# sourceMappingURL\=source\-map\.css\.map/.test(css), 'should include sourceMapppingUrl');
+		test.ok(/\/\*# sourceMappingURL=source\-map\.css\.map/.test(css), 'should include sourceMapppingUrl');
 
 		var map = grunt.file.read('test/tmp/source-map.css.map');
 		test.ok(/test\.scss/.test(map), 'should include the main file in sourceMap at least');
@@ -43,10 +43,10 @@ exports.sass = {
 		test.expect(2);
 
 		var css = grunt.file.read('test/tmp/source-map-simple.css');
-		test.ok(/\/\*\# sourceMappingURL\=source\-map-simple\.css\.map/.test(css), 'should include sourceMappingUrl');
+		test.ok(/\/\*# sourceMappingURL=source\-map-simple\.css\.map/.test(css), 'should include sourceMappingUrl');
 
 		var map = grunt.file.read('test/tmp/source-map-simple.css.map');
-		test.ok(/test\.scss\"/.test(map), 'should include the main file in sourceMap at least');
+		test.ok(/test\.scss"/.test(map), 'should include the main file in sourceMap at least');
 		test.done();
 	},
 	precision: function (test) {


### PR DESCRIPTION
I'd like to allow callers of the plugin to specify whichever version of node-sass they want, so that it's easier to pin to an exact version or version range. This should also reduce the maintenance overhead for grunt-sass, since the plugin no longer has to be updated every time there is a new node-sass (beta) release.

Express node-sass as both a peerDependency and devDependency, so that it's still possible to run the test suite. Prefer non-beta version for the test suite, since the beta dist-tag seems to prevent the peer dependency from being satisfied on npm v2.14.12.

Part of the reason for doing this is that node-sass v3.5.3 made a certain practice in 3.4.0 fatal, which broke our build pipeline overnight.