### PR TITLE
Loosen node-sass dependency requirement to ^3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "each-async": "^1.0.0",
-    "node-sass": "^3.7.0",
+    "node-sass": "^3.4.0",
     "object-assign": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This provides similar functionality to that described in https://github.com/sindresorhus/grunt-sass/pull/266, which regressed in a401b042bf5893762ffad2e277100c67f294f65b.

Scenario: I have a project that relies on the deprecated behaviors provided by `node-sass@3.4.x`. The [3.5.x changes](https://medium.com/@xzyfer/why-node-sass-broke-your-code-and-semver-1b3e409c57b9#.39qyl08av) broke this, which were pulled down by `grunt-sass`. It will take some time to update my code to be compatible.

I resolved this by hardcoding to `node-sass@3.4.2` dependency as noted in the above PR. This worked well until `grunt-sass@1.2.0` which bumped the `node-sass` dependency to `^3.7.0`. Now npm's deduping no longer applies, as the two dependencies are incompatible, and `grunt-sass` will always compile with `node-sass` versions greater than 3.7 regardless of what an app has specified.

As a workaround, I now have to hardcode both `grunt-sass@1.1.0` and `node-sass@3.4.2`. While this works, it's less flexible than loosening the dependency, and contrary to the spirit of "let me choose my own Sass compiler" outlined in the above PR.

This commit should work with both use cases: by default it'll still pull down the latest `node-sass` in the 3.x range, while still allowing apps that rely on deprecated 3.4 behavior to compile against an earlier version.