### PR TITLE
Add successLog option to print the success log

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,12 @@ See the `node-sass` [options](https://github.com/sass/node-sass#options), except
 
 The default value for the `precision` option is `10`, so you don't have to change it when using Bootstrap.
 
+Set `successLog` to `true` to print the CSS file being created and total duration taken in ms!
+
+```
+$ Write ./path/to/file.css
+$ Total duration 7ms!
+```
 
 ## License
 

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -34,8 +34,8 @@ module.exports = function (grunt) {
 				grunt.file.write(el.dest, res.css);
 
 				if (opts.successLog) {
-					grunt.log.writeln(('Write '+ el.dest).green);
-					grunt.log.writeln(('Total duration: ' + res.stats.duration + 'ms!').yellow);
+					grunt.log.writeln('Write '.green + (el.dest).green);
+					grunt.log.writeln('Total duration: '.yellow + (res.stats.duration + 'ms!').yellow);
 				}
 
 				if (opts.sourceMap) {

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -33,6 +33,11 @@ module.exports = function (grunt) {
 
 				grunt.file.write(el.dest, res.css);
 
+				if (opts.successLog) {
+					grunt.log.writeln(('Write '+ el.dest).green);
+					grunt.log.writeln(('Total duration: ' + res.stats.duration + 'ms!').yellow);
+				}
+
 				if (opts.sourceMap) {
 					grunt.file.write(this.options.sourceMap, res.map);
 				}


### PR DESCRIPTION
I had this use case to print the success log for sass dev task in one of my current projects! Though I was able to pull some hacks to print the css file name from my Gruntfile.js, but I couldn't do much about duration without having access to `res.stats` object. 

This seems to be the clean way to do it! Merge it, if it makes sense to you guys & helps larger audience!
