### PR TITLE
Update node-sass dependency to version compliant with nodejs. Yes, I read Readme.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 language: node_js
 node_js:
+  - '9'
+  - '8'
   - '7'
   - '6'
   - '5'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-sass",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Compile Sass to CSS using node-sass",
   "license": "MIT",
   "repository": "sindresorhus/grunt-sass",
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "each-async": "^1.0.0",
-    "node-sass": "^4.0.0",
+    "node-sass": "^4.7.2",
     "object-assign": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Yes, I read the Readme and the article on semver.
I understand this pull request should not be necessary, in theory.

However, in practice, on a clean Docker VM with a fresh nodejs and a brand new install of grunt-sass, I **_do not_** get a compatible version of node-sass. I realize that semver dictates the latest minor version should be installed, but this consistently does not happen. And I have no idea why.