### PR TITLE
Node 10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
   - '8'
+  - '10.1'

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"libsass"
 	],
 	"dependencies": {
-		"node-sass": "^4.7.2"
+		"node-sass": "^4.9.0"
 	},
 	"devDependencies": {
 		"grunt": "^1.0.1",


### PR DESCRIPTION
Bump node-sass to 4.9, and include 10 in the travis yml.