### PR TITLE
Add file, line and column to error message

### DIFF
--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -37,8 +37,8 @@ module.exports = grunt => {
 			}));
 
 			done();
-    })().catch((err) => {
-      grunt.fatal(`${err.message}\n${err.file} (${err.line}:${err.column})`);
-    });
+		})().catch(err => {
+			grunt.fatal(`${err.message}\n${err.file} (${err.line}:${err.column})`);
+		});
 	});
 };

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -37,6 +37,8 @@ module.exports = grunt => {
 			}));
 
 			done();
-		})().catch(grunt.fatal);
+    })().catch((err) => {
+      grunt.fatal(`${err.message}\n${err.file} (${err.line}:${err.column})`);
+    });
 	});
 };


### PR DESCRIPTION
Optimizes error output and by that simplifies bug fixing.

Before:
`Fatal error: Incompatible units: 'px' and 'Px'.`

Now:
`Fatal error: Incompatible units: 'px' and 'Px'.`
`/Users/******/sass/*****/_test.scss (7:13)`