### PR TITLE
Node 10 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"grunt-cli": "^1.2.0",
 		"grunt-contrib-clean": "^1.0.0",
 		"grunt-contrib-nodeunit": "^1.0.0",
-		"node-sass": "^4.7.2",
+		"node-sass": "^4.9.3",
 		"xo": "*"
 	},
 	"peerDependencies": {

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -23,10 +23,11 @@ module.exports = grunt => {
 					return;
 				}
 
-				const result = await util.promisify(options.implementation.render)(Object.assign({}, options, {
+				const result = await util.promisify(options.implementation.render)({
+					...options,
 					file: src,
 					outFile: item.dest
-				}));
+				});
 
 				grunt.file.write(item.dest, result.css);
 


### PR DESCRIPTION
I've tried to use the grunt-sass with Node 10 and I've experienced problems because node-sass 4.7.2 doesn't support the new Node.

- Fixed tests (they didn't run due to linter errors)
- Updated node-sass to [4.9.3](https://github.com/sass/node-sass/releases/tag/v4.9.3) (They added Node 10 support in [4.9.0](https://github.com/sass/node-sass/releases/tag/v4.9.0))

Can you publish the new version after merging the PR?