### PR TITLE
Improves readability on Usage docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ grunt.initConfig({
 		},
 		dist: {
 			files: {
-				'main.css': 'main.scss'
+				'output/path/main.css': 'input/path/main.scss'
 			}
 		}
 	}
@@ -75,7 +75,7 @@ grunt.initConfig({
 		},
 		dist: {
 			files: {
-				'main.css': 'main.scss'
+				'output/path/main.css': 'input/path/main.scss'
 			}
 		}
 	}

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,8 @@ $ npm install --save-dev node-sass grunt-sass
 
 ## Usage
 
+Without globbing folders:
+
 ```js
 const sass = require('node-sass');
 
@@ -51,6 +53,36 @@ grunt.initConfig({
 			}
 		}
 	}
+});
+
+grunt.registerTask('default', ['sass']);
+```
+
+Globbing folders:
+
+```js
+const sass = require('node-sass');
+
+require('load-grunt-tasks')(grunt);
+
+grunt.initConfig({
+  sass: {
+    compile: {
+      options: {
+        implementation: sass,
+        sourceMap: true,
+        outputStyle: "expanded"
+      },
+      files: [{
+        expand: true,         // Enable dynamic expansion.
+        cwd: 'src/scss/',     // Src matches are relative to this path.
+        src: ['**/*.scss'],   // Actual pattern(s) to match.
+        dest: 'css/',         // Destination path prefix.
+        ext: '.css',          // Dest filepaths will have this extension.
+        extDot: 'first'       // Extensions in filenames begin after the first dot
+      }]
+    }
+  }
 });
 
 grunt.registerTask('default', ['sass']);


### PR DESCRIPTION
I'm a newbie learning Grunt and had a hard time, searching for what some objects are meant for. Even though it seems really easy to me now, I can't say that it won't happen again to another person, as [this issue](https://github.com/sindresorhus/grunt-sass/issues/140) shows.

If you think that the [latest commit](https://github.com/sindresorhus/grunt-sass/commit/732e933c6b76cf1d2f4789681b7001a69c7eebd4) is too verbose , I'm able to open another PR in which we just reference the Grunt documentation "[`Building the files object dynamically`](https://gruntjs.com/configuring-tasks#building-the-files-object-dynamically)":

> Besides that, if you want to glob and render a whole Sass folder easily, you should read the "Building the files object dynamically" on Grunt documentation for configuring tasks.