### PR TITLE
noFail option to log error instead of failing Grunt in case of an error

### DIFF
--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -8,6 +8,7 @@ module.exports = grunt => {
 		const done = this.async();
 
 		const options = this.options({
+			noFail: false,
 			precision: 10
 		});
 
@@ -36,6 +37,12 @@ module.exports = grunt => {
 					grunt.file.write(filePath, result.map);
 				}
 			}));
-		})().catch(grunt.fatal).then(done);
+		})().catch(error => {
+			if (options.noFail) {
+				grunt.log.error(error);
+			} else {
+				grunt.fatal(error);
+			}
+		}).then(done);
 	});
 };


### PR DESCRIPTION
When running node-sass with a watch tasks stopping the whole process due to
intermittent syntax errors is not good. Make it possible to configure the task
to log errors only.

This allows for such configs:

```
develWatch: {
	options: {
		// ...
		noFail: true
	},
	dest: "...",
	src: "..."
}
```