### PR TITLE
Added error event and fixed Grunt error message

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ $ npm install --save-dev node-sass grunt-sass
 ```js
 const sass = require('node-sass');
 
+// You may need to load the module `npm install --save-dev load-grunt-tasks`
 require('load-grunt-tasks')(grunt);
 
 grunt.initConfig({
@@ -49,6 +50,9 @@ grunt.initConfig({
 	}
 });
 
+// You can also use `grunt.loadNpmTasks('grunt-sass');`
+// instead of `require('load-grunt-tasks')(grunt);`
+
 grunt.registerTask('default', ['sass']);
 ```
 
@@ -60,7 +64,6 @@ Note that when using Dart Sass, **synchronous compilation is twice as fast as as
 const Fiber = require('fibers');
 const sass = require('sass');
 
-// You may need to load the module `npm install --save-dev load-grunt-tasks`
 require('load-grunt-tasks')(grunt);
 
 grunt.initConfig({
@@ -78,9 +81,6 @@ grunt.initConfig({
 	}
 });
 
-// You can also use `grunt.loadNpmTasks('grunt-sass');`
-// instead of `require('load-grunt-tasks')(grunt);`
-
 grunt.registerTask('default', ['sass']);
 ```
 
@@ -94,7 +94,7 @@ See the Node Sass [options](https://github.com/sass/node-sass#options), except f
 The default value for the `precision` option is `10`, so you don't have to change it when using Bootstrap.
 
 ## Events
-`grunt-sass-error` Called when an error occurs.
+`grunt-sass-error` - Called when an error occurs.
 
 Example
 

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,7 @@ Note that when using Dart Sass, **synchronous compilation is twice as fast as as
 const Fiber = require('fibers');
 const sass = require('sass');
 
+// You may need to load the module `npm install --save-dev load-grunt-tasks`
 require('load-grunt-tasks')(grunt);
 
 grunt.initConfig({
@@ -77,6 +78,9 @@ grunt.initConfig({
 	}
 });
 
+// You can also use `grunt.loadNpmTasks('grunt-sass');`
+// instead of `require('load-grunt-tasks')(grunt);`
+
 grunt.registerTask('default', ['sass']);
 ```
 
@@ -88,3 +92,14 @@ Files starting with `_` are ignored to match the expected [Sass partial behaviou
 See the Node Sass [options](https://github.com/sass/node-sass#options), except for `file`, `outFile`, `success`, `error`.
 
 The default value for the `precision` option is `10`, so you don't have to change it when using Bootstrap.
+
+## Events
+`grunt-sass-error` Called when an error occurs.
+
+Example
+
+```
+grunt.event.on('grunt-sass-error', function(err){
+    console.log(err);
+});
+```

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -37,7 +37,8 @@ module.exports = grunt => {
 				}
 			}));
 		})().catch(error => {
-			grunt.fatal(error.formatted || error);
+			grunt.event.emit('grunt-sass-error', error);
+			grunt.fail.fatal(error.formatted || error);
 		}).then(done);
 	});
 };


### PR DESCRIPTION
- Added error event and fixed Grunt error message
- Added in Readme.mb description

```
			grunt.event.emit('grunt-sass-error', error);
			grunt.fail.fatal(error.formatted || error);
```

https://gruntjs.com/api/grunt.fail


